### PR TITLE
Profiling causes "Value out of range for int" error

### DIFF
--- a/src/main/clojure/clojure/contrib/profile.clj
+++ b/src/main/clojure/clojure/contrib/profile.clj
@@ -85,7 +85,7 @@ profiling code."}  *enable-profiling* true)
   (reduce (fn [m [k v]]
             (let [cnt (count v)
                   sum (reduce + v)]
-              (assoc m k {:mean (int (/ sum cnt))
+              (assoc m k {:mean (long (/ sum cnt))
                           :min (apply min v)
                           :max (apply max v)
                           :count cnt


### PR DESCRIPTION
Hi,

I was trying to profile some clojure code of mine that takes ~3min to execute on a fairly large dataset, but I ran into this error:

Exception in thread "main" java.lang.IllegalArgumentException: Value out of range for int: 9846757000 (main.clj:0)
    at clojure.lang.Compiler.eval(Compiler.java:5440)
    at clojure.lang.Compiler.load(Compiler.java:5857)
    at clojure.lang.Compiler.loadFile(Compiler.java:5820)
    at clojure.main$load_script.invoke(main.clj:221)
    at clojure.main$script_opt.invoke(main.clj:273)
    at clojure.main$main.doInvoke(main.clj:354)
    at clojure.lang.RestFn.invoke(RestFn.java:409)
    at clojure.lang.Var.invoke(Var.java:365)
    at clojure.lang.AFn.applyToHelper(AFn.java:163)
    at clojure.lang.Var.applyTo(Var.java:482)
    at clojure.main.main(main.java:37)
Caused by: java.lang.IllegalArgumentException: Value out of range for int: 9846757000
    at clojure.lang.RT.intCast(RT.java:950)
    at clojure.lang.RT.intCast(RT.java:922)
    at clojure.contrib.profile$summarize$fn__1787.invoke(profile.clj:88)
    at clojure.core$r.invoke(core.clj:799)
    at clojure.contrib.profile$summarize.invoke(profile.clj:85)
    at fraud.core$main.invoke(core.clj:55)
    at fraud.main$eval1857.invoke(main.clj:4)
    at clojure.lang.Compiler.eval(Compiler.java:5424)
    ... 10 more

I'm submitting a pretty simple fix.  I've just casted the mean value in the profiling summary to a long instead of an int.

Ideally I would have written a test for this as well, but honestly I just started using clojure.contrib.profile an hour ago, and I don't know enough to write a meaningful test quickly.  
