### PR TITLE
Removed -mindepth 1 from find.

### DIFF
--- a/launchers/bash/clj-env-dir
+++ b/launchers/bash/clj-env-dir
@@ -46,7 +46,7 @@ set -o errexit
 if [ -n "${CLOJURE_EXT:-}" ]; then
     OLD="$IFS"
     IFS=":"
-    EXT="$(find -H $CLOJURE_EXT -mindepth 1 -maxdepth 1 -print0 | tr \\0 \:)"
+    EXT="$(find -H $CLOJURE_EXT -maxdepth 1 -print0 | tr \\0 \:)"
     IFS="$OLD"
     if [ -n "${CLASSPATH:-}" ]; then
         export CLASSPATH="$EXT$CLASSPATH"


### PR DESCRIPTION
It was not working on my Ubuntu when adding the following to .bashrc:

`export CLOJURE_EXT=$HOME/.m2/repository/org/clojure/clojure/1.6.0/clojure-1.6.0.jar`

Maybe I was not using it in the right way, but I found that removing -mindepth 1 makes `find` work with individual jars as well as folders (tested on GNU bash, version 4.3.11(1)-release (x86_64-pc-linux-gnu) only).
